### PR TITLE
Fix for issus #10 Whitelisting doesn't work

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/FastClasspathScanner.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/FastClasspathScanner.java
@@ -1039,7 +1039,7 @@ public class FastClasspathScanner {
                     // Reached a whitelisted path -- can start scanning directories and files from this point
                     inWhitelistedPath = true;
                     break;
-                } else if (whitelistedPath.startsWith(relativePath)) {
+                } else if (whitelistedPath.startsWith(relativePath) || relativePath.equals("/")) {
                     // In a path that is a prefix of a whitelisted path -- keep recursively scanning dirs
                     // in case we can reach a whitelisted path.
                     keepRecursing = true;


### PR DESCRIPTION
When scan root dir for classes. The relative path will be “/”.But the
whitelisted path start without “/“.So, fix it with keeping recursing
for “/“.Please check if it’s suitable.