### PR TITLE
Fixing squid:S2221 and squid:S1210 rules

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
@@ -408,6 +408,26 @@ public class ClassInfo implements Comparable<ClassInfo> {
     }
 
     @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (this.getClass() == obj.getClass()) {
+            ClassInfo other = (ClassInfo) obj;
+            return className != null ? className.equals(other.className) : other.className == null;
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return className != null ? className.hashCode() : 33;
+    }
+
+    @Override
     public String toString() {
         return className;
     }

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/ClasspathFinder.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/ClasspathFinder.java
@@ -31,6 +31,7 @@ package io.github.lukehutch.fastclasspathscanner.classpath;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
@@ -108,16 +109,16 @@ public class ClasspathFinder {
             // a classpath element, and/or the path tree may no longer conform to the package tree. 
             return resolveBasePath.resolve(Paths.get(new URL(pathStr).toURI())) //
                     .toRealPath(LinkOption.NOFOLLOW_LINKS);
-        } catch (final Exception e) {
+        } catch (final IOException|URISyntaxException e) {
             try {
                 return resolveBasePath.resolve(pathStr).toRealPath(LinkOption.NOFOLLOW_LINKS);
-            } catch (final Exception e2) {
+            } catch (final IOException e2) {
                 try {
                     final File file = new File(pathElementStr);
                     if (file.exists()) {
                         return file.toPath().toRealPath(LinkOption.NOFOLLOW_LINKS);
                     }
-                } catch (final Exception e3) {
+                } catch (final IOException e3) {
                     // One of the above should have worked, so if we got here, the path element is junk.
                     if (FastClasspathScanner.verbose) {
                         Log.log("Exception while trying to read classpath element " + pathStr + " : "


### PR DESCRIPTION

This pull request is focused on resolving occurrences of some Sonar rules: 
squid:S2221 - “"Exception" should not be caught when not required by called methods”. 
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S2221
squid:S1210 - ""equals(Object obj)" should be overridden along with the "compareTo(T obj)" method"
You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1210
Please let me know if you have any questions.
Artyom Melnikov.