### PR TITLE
Fixing squid:S1319 - Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/FastClasspathScanner.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/FastClasspathScanner.java
@@ -31,11 +31,7 @@ package io.github.lukehutch.fastclasspathscanner;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
@@ -977,7 +973,7 @@ public class FastClasspathScanner {
      *            the StaticFinalFieldMatchProcessor to call when a match is found.
      */
     public FastClasspathScanner matchStaticFinalFieldNames(
-            final HashSet<String> fullyQualifiedStaticFinalFieldNames,
+            final Set<String> fullyQualifiedStaticFinalFieldNames,
             final StaticFinalFieldMatchProcessor staticFinalFieldMatchProcessor) {
         for (final String fullyQualifiedFieldName : fullyQualifiedStaticFinalFieldNames) {
             final int lastDotIdx = fullyQualifiedFieldName.lastIndexOf('.');

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
@@ -28,12 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.classfileparser;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 public class ClassInfo implements Comparable<ClassInfo> {
     /** Name of the class/interface/annotation. */
@@ -133,13 +128,13 @@ public class ClassInfo implements Comparable<ClassInfo> {
     }
 
     /** The set of classes related to this one. */
-    public HashMap<RelType, HashSet<ClassInfo>> relatedTypeToClassInfoSet = new HashMap<>();
+    public Map<RelType, HashSet<ClassInfo>> relatedTypeToClassInfoSet = new HashMap<>();
 
     /**
      * The static constant initializer values of static final fields, if a StaticFinalFieldMatchProcessor matched a
      * field in this class.
      */
-    public HashMap<String, Object> fieldValues;
+    public Map<String, Object> fieldValues;
 
     public ClassInfo(final String className) {
         this.className = className;
@@ -316,7 +311,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
     }
 
     private static ClassInfo getOrCreateClassInfo(final String className,
-            final HashMap<String, ClassInfo> classNameToClassInfo) {
+            final Map<String, ClassInfo> classNameToClassInfo) {
         ClassInfo classInfo = classNameToClassInfo.get(className);
         if (classInfo == null) {
             classNameToClassInfo.put(className, classInfo = new ClassInfo(className));
@@ -324,7 +319,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
         return classInfo;
     }
 
-    public void addSuperclass(final String superclassName, final HashMap<String, ClassInfo> classNameToClassInfo) {
+    public void addSuperclass(final String superclassName, final Map<String, ClassInfo> classNameToClassInfo) {
         if (superclassName != null && !superclassName.equals("java.lang.Object")) {
             final ClassInfo superclassClassInfo = getOrCreateClassInfo(scalaBaseClassName(superclassName),
                     classNameToClassInfo);
@@ -333,7 +328,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
         }
     }
 
-    public void addAnnotation(final String annotationName, final HashMap<String, ClassInfo> classNameToClassInfo) {
+    public void addAnnotation(final String annotationName, final Map<String, ClassInfo> classNameToClassInfo) {
         final ClassInfo annotationClassInfo = getOrCreateClassInfo(scalaBaseClassName(annotationName),
                 classNameToClassInfo);
         annotationClassInfo.isAnnotation = true;
@@ -342,7 +337,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
     }
 
     public void addImplementedInterface(final String interfaceName,
-            final HashMap<String, ClassInfo> classNameToClassInfo) {
+            final Map<String, ClassInfo> classNameToClassInfo) {
         final ClassInfo interfaceClassInfo = getOrCreateClassInfo(scalaBaseClassName(interfaceName),
                 classNameToClassInfo);
         interfaceClassInfo.isInterface = true;
@@ -350,7 +345,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
         interfaceClassInfo.addRelatedClass(RelType.CLASSES_IMPLEMENTING, this);
     }
 
-    public void addFieldType(final String fieldTypeName, final HashMap<String, ClassInfo> classNameToClassInfo) {
+    public void addFieldType(final String fieldTypeName, final Map<String, ClassInfo> classNameToClassInfo) {
         final String fieldTypeBaseName = scalaBaseClassName(fieldTypeName);
         final ClassInfo fieldTypeClassInfo = getOrCreateClassInfo(fieldTypeBaseName, classNameToClassInfo);
         this.addRelatedClass(RelType.FIELD_TYPES, fieldTypeClassInfo);
@@ -365,7 +360,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
 
     /** Add a class that has just been scanned (as opposed to just referenced by a scanned class). */
     public static ClassInfo addScannedClass(final String className, final boolean isInterface,
-            final boolean isAnnotation, final HashMap<String, ClassInfo> classNameToClassInfo) {
+            final boolean isAnnotation, final Map<String, ClassInfo> classNameToClassInfo) {
         // Handle Scala auxiliary classes (companion objects ending in "$" and trait methods classes
         // ending in "$class")
         final boolean isCompanionObjectClass = className.endsWith("$");

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
@@ -7,6 +7,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -114,7 +115,7 @@ public class ClassfileBinaryParser {
      */
     private static void addFieldTypeDescriptorParts(final String className, final String typeDescriptor,
             final ScanSpec scanSpec, final ClassInfo classInfo,
-            final HashMap<String, ClassInfo> classNameToClassInfo) {
+            final Map<String, ClassInfo> classNameToClassInfo) {
         // Check if the type of this field falls within a non-blacklisted package,
         // and if so, record the field and its type
         final Matcher matcher = TYPE_PARAM_PATTERN.matcher(typeDescriptor);
@@ -141,8 +142,8 @@ public class ClassfileBinaryParser {
      * @return true, if this is the first time a class was encountered on the classpath.
      */
     public static void readClassInfoFromClassfileHeader(final String relativePath, final InputStream inputStream,
-            final HashMap<String, HashSet<String>> classNameToStaticFinalFieldsToMatch, final ScanSpec scanSpec, //
-            final HashMap<String, ClassInfo> classNameToClassInfo) {
+            final Map<String, HashSet<String>> classNameToStaticFinalFieldsToMatch, final ScanSpec scanSpec, //
+            final Map<String, ClassInfo> classNameToClassInfo) {
 
         try (final DataInputStream inp = new DataInputStream(new BufferedInputStream(inputStream, 8192))) {
             // Magic number

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classgraph/ClassGraphBuilder.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classgraph/ClassGraphBuilder.java
@@ -28,21 +28,16 @@
  */
 package io.github.lukehutch.fastclasspathscanner.classgraph;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
+import java.util.*;
 
 import io.github.lukehutch.fastclasspathscanner.classfileparser.ClassInfo;
 import io.github.lukehutch.fastclasspathscanner.classfileparser.ClassInfo.ClassType;
 import io.github.lukehutch.fastclasspathscanner.classfileparser.ClassInfo.RelType;
 
 public class ClassGraphBuilder {
-    private final HashMap<String, ClassInfo> classNameToClassInfo;
+    private final Map<String, ClassInfo> classNameToClassInfo;
 
-    public ClassGraphBuilder(final HashMap<String, ClassInfo> classNameToClassInfo) {
+    public ClassGraphBuilder(final Map<String, ClassInfo> classNameToClassInfo) {
         this.classNameToClassInfo = classNameToClassInfo;
         final ArrayList<ClassInfo> allClassInfo = new ArrayList<>(classNameToClassInfo.values());
 

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/ClasspathFinder.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/ClasspathFinder.java
@@ -37,6 +37,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.ServiceLoader;
 import java.util.jar.Manifest;
 
@@ -305,7 +306,7 @@ public class ClasspathFinder {
         }
         classLoadersSet.add(Thread.currentThread().getContextClassLoader());
         addAllParentClassloaders(ClasspathFinder.class, classLoadersSet);
-        final ArrayList<ClassLoader> classLoaders = classLoadersSet.getList();
+        final List<ClassLoader> classLoaders = classLoadersSet.getList();
         classLoaders.remove(null);
 
         // Find all ClassLoaderHandlers registered using ServiceLoader, given known ClassLoaders 
@@ -370,7 +371,7 @@ public class ClasspathFinder {
      * Returns the list of all unique File objects representing directories or zip/jarfiles on the classpath, in
      * classloader resolution order. Classpath elements that do not exist are not included in the list.
      */
-    public ArrayList<File> getUniqueClasspathElements() {
+    public List<File> getUniqueClasspathElements() {
         if (!initialized) {
             parseSystemClasspath();
         }

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/RecursiveScanner.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/RecursiveScanner.java
@@ -36,6 +36,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -382,7 +383,7 @@ public class RecursiveScanner {
      * match is identified. If scanTimestampsOnly is false, only scans timestamps of files.
      */
     private void scan(final boolean scanTimestampsOnly) {
-        final ArrayList<File> uniqueClasspathElts = classpathFinder.getUniqueClasspathElements();
+        final List<File> uniqueClasspathElts = classpathFinder.getUniqueClasspathElements();
         if (FastClasspathScanner.verbose) {
             Log.log("*** Starting scan" + (scanTimestampsOnly ? " (scanning classpath timestamps only)" : "")
                     + " ***");

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/AdditionOrderedSet.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/AdditionOrderedSet.java
@@ -30,6 +30,7 @@ package io.github.lukehutch.fastclasspathscanner.utils;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 /**
  * A simplified set that has O(1) add time, but also preserves a list of elements in the order they were added.
@@ -49,7 +50,7 @@ public class AdditionOrderedSet<T> {
     }
 
     /** Get the elements in addition order (i.e. in the order they were added) */
-    public ArrayList<T> getList() {
+    public List<T> getList() {
         return list;
     }
 

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/HashClassfileContents.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/HashClassfileContents.java
@@ -34,6 +34,7 @@ import java.math.BigInteger;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.HashMap;
+import java.util.Map;
 
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
@@ -86,7 +87,7 @@ public class HashClassfileContents {
     /**
      * Returns the mapping from class name to hash of classfile contents after the call to .scan().
      */
-    public HashMap<String, String> getClassNameToClassfileHash() {
+    public Map<String, String> getClassNameToClassfileHash() {
         return this.classNameToClassfileHash;
     }
 }

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/test/FastClasspathScannerTest.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/test/FastClasspathScannerTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -327,7 +328,7 @@ public class FastClasspathScannerTest {
 
     @Test
     public void hashContents() throws Exception {
-        final HashMap<String, String> classNameToClassfileHash = new HashClassfileContents(WHITELIST_PACKAGE).scan()
+        final Map<String, String> classNameToClassfileHash = new HashClassfileContents(WHITELIST_PACKAGE).scan()
                 .getClassNameToClassfileHash();
         final String hash = classNameToClassfileHash.get(Cls.class.getName());
         assertThat(hash).isNotNull();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList"”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1319
 Please let me know if you have any questions.
 Artyom Melnikov.