### PR TITLE
Fixing squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassInfo.java
@@ -325,7 +325,7 @@ public class ClassInfo implements Comparable<ClassInfo> {
     }
 
     public void addSuperclass(final String superclassName, final HashMap<String, ClassInfo> classNameToClassInfo) {
-        if (superclassName != null && !superclassName.equals("java.lang.Object")) {
+        if (superclassName != null && !"java.lang.Object".equals(superclassName)) {
             final ClassInfo superclassClassInfo = getOrCreateClassInfo(scalaBaseClassName(superclassName),
                     classNameToClassInfo);
             this.addRelatedClass(RelType.SUPERCLASSES, superclassClassInfo);

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
@@ -224,7 +224,7 @@ public class ClassfileBinaryParser {
 
             // The fully-qualified class name of this class, with slashes replaced with dots
             final String className = readRefdClassName(inp, constantPool);
-            if (className.equals("java.lang.Object")) {
+            if ("java.lang.Object".equals(className)) {
                 // Don't process java.lang.Object
                 return;
             }
@@ -255,7 +255,7 @@ public class ClassfileBinaryParser {
             if (FastClasspathScanner.verbose) {
                 Log.log("Found " //
                         + (isAnnotation ? "annotation" : isInterface ? "interface" : "class") + " " + className //
-                        + (superclassName == null || superclassName.equals("java.lang.Object") ? ""
+                        + (superclassName == null || "java.lang.Object".equals(superclassName) ? ""
                                 : " with " + (isInterface && !isAnnotation ? "superinterface" : "superclass") + " "
                                         + superclassName));
             }
@@ -308,7 +308,7 @@ public class ClassfileBinaryParser {
                 for (int j = 0; j < attributesCount; j++) {
                     final String attributeName = readRefdString(inp, constantPool);
                     final int attributeLength = inp.readInt();
-                    if (isStaticFinal && isMatchedFieldName && attributeName.equals("ConstantValue")) {
+                    if (isStaticFinal && isMatchedFieldName && "ConstantValue".equals(attributeName)) {
                         // http://docs.oracle.com/javase/specs/jvms/se7/html/jvms-4.html#jvms-4.7.2
                         Object constValue = constantPool[inp.readUnsignedShort()];
                         // byte, char, short and boolean constants are all stored as 4-byte int
@@ -350,7 +350,7 @@ public class ClassfileBinaryParser {
                         }
                         classInfo.addFieldConstantValue(fieldName, constValue);
                         foundConstantValue = true;
-                    } else if (attributeName.equals("Signature")) {
+                    } else if ("Signature".equals(attributeName)) {
                         // Check if the type signature of this field falls within a non-blacklisted
                         // package, and if so, record the field type. The type signature contains
                         // type parameters, whereas the type descriptor does not.

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/classloaderhandler/JBossClassLoaderHandler.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/classloaderhandler/JBossClassLoaderHandler.java
@@ -40,7 +40,7 @@ public class JBossClassLoaderHandler implements ClassLoaderHandler {
     @Override
     public boolean handle(final ClassLoader classloader, final ClasspathFinder classpathFinder) throws Exception {
         for (Class<?> c = classloader.getClass(); c != null; c = c.getSuperclass()) {
-            if (c.getName().equals("org.jboss.modules.ModuleClassLoader")) {
+            if ("org.jboss.modules.ModuleClassLoader".equals(c.getName())) {
                 final Method getResourceLoaders = c.getDeclaredMethod("getResourceLoaders");
                 if (!getResourceLoaders.isAccessible()) {
                     getResourceLoaders.setAccessible(true);

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/classloaderhandler/WeblogicClassLoaderHandler.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classpath/classloaderhandler/WeblogicClassLoaderHandler.java
@@ -36,7 +36,7 @@ public class WeblogicClassLoaderHandler implements ClassLoaderHandler {
     @Override
     public boolean handle(final ClassLoader classloader, final ClasspathFinder classpathFinder) throws Exception {
         for (Class<?> c = classloader.getClass(); c != null; c = c.getSuperclass()) {
-            if (c.getName().equals("weblogic.utils.classloaders.ChangeAwareClassLoader")) {
+            if ("weblogic.utils.classloaders.ChangeAwareClassLoader".equals(c.getName())) {
                 final Method getClassPath = c.getDeclaredMethod("getClassPath");
                 if (!getClassPath.isAccessible()) {
                     getClassPath.setAccessible(true);

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/RecursiveScanner.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/RecursiveScanner.java
@@ -365,7 +365,7 @@ public class RecursiveScanner {
                             if (fileIsWhitelisted) {
                                 // Scan whitelisted file
                                 scanFile(classpathElt, subFileReal,
-                                        relativePath.equals("/") ? subFileName : relativePath + subFileName,
+                                        "/".equals(relativePath) ? subFileName : relativePath + subFileName,
                                         scanTimestampsOnly);
                             }
                         }

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
@@ -305,7 +305,7 @@ public class ScanSpec {
         for (final String whitelistedPath : whitelistedPathPrefixes) {
             if (path.startsWith(whitelistedPath)) {
                 return ScanSpecPathMatch.WITHIN_WHITELISTED_PATH;
-            } else if (whitelistedPath.startsWith(path) || path.equals("/")) {
+            } else if (whitelistedPath.startsWith(path) || "/".equals(path)) {
                 return ScanSpecPathMatch.ANCESTOR_OF_WHITELISTED_PATH;
             }
         }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - “Strings literals should be placed on the left side when checking for equality”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
Artyom Melnikov.