### PR TITLE
Fixing squid:S1118 and squid:S1871

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classfileparser/ClassfileBinaryParser.java
@@ -15,6 +15,10 @@ import io.github.lukehutch.fastclasspathscanner.scanner.ScanSpec;
 import io.github.lukehutch.fastclasspathscanner.utils.Log;
 
 public class ClassfileBinaryParser {
+    private ClassfileBinaryParser() {
+
+    }
+
     /**
      * Read annotation entry from classfile.
      */
@@ -63,15 +67,13 @@ public class ClassfileBinaryParser {
         case 'Z':
         case 's':
             // const_value_index
+        case 'c':
+            // class_info_index
             inp.skipBytes(2);
             break;
         case 'e':
             // enum_const_value
             inp.skipBytes(4);
-            break;
-        case 'c':
-            // class_info_index
-            inp.skipBytes(2);
             break;
         case '@':
             // Complex (nested) annotation
@@ -193,16 +195,15 @@ public class ClassfileBinaryParser {
                 case 10: // method ref
                 case 11: // interface ref
                 case 12: // name and type
-                    inp.skipBytes(4); // two shorts
+                    // two shorts
+                case 18: // invoke dynamic
+                    inp.skipBytes(4);
                     break;
                 case 15: // method handle
                     inp.skipBytes(3);
                     break;
                 case 16: // method type
                     inp.skipBytes(2);
-                    break;
-                case 18: // invoke dynamic
-                    inp.skipBytes(4);
                     break;
                 default:
                     // System.err.println("Unkown tag value for constant pool entry: " + tag);
@@ -337,7 +338,6 @@ public class ClassfileBinaryParser {
                         case "Ljava.lang.String;":
                             // Field is int, long, float, double or String => object is already in correct
                             // wrapper type (Integer, Long, Float, Double or String), nothing to do
-                            break;
                         default:
                             // Should never happen:
                             // constant values can only be stored as an int, long, float, double or String

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/Log.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/utils/Log.java
@@ -3,6 +3,10 @@ package io.github.lukehutch.fastclasspathscanner.utils;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 
 public class Log {
+    private Log() {
+
+    }
+    
     public static void log(final String msg) {
         System.err.println(FastClasspathScanner.class.getSimpleName() + ": " + msg);
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules:
squid:S1118 - "Utility classes should not have public constructors".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S1118
squid:S1871 - "Two branches in the same conditional structure should not have exactly the same implementation".
You can find more information about the issue here: 
https://sonarqube.com/coding_rules#q=squid:S1871
Please let me know if you have any questions.
Artyom Melnikov