### PR TITLE
Adding OSGi metadata generation to distribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,6 +5,7 @@
 	<artifactId>fast-classpath-scanner</artifactId>
 	<version>2.0.4-SNAPSHOT</version>
 	<name>Fast Classpath Scanner</name>
+	<packaging>bundle</packaging>
 
 	<description>
 	Uber-fast, ultra-lightweight Java classpath scanner. Scans the classpath by parsing the classfile  binary format directly rather than by using reflection.
@@ -137,6 +138,10 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+			</plugin>
 		</plugins>
 		<pluginManagement>
 			<plugins>
@@ -152,6 +157,25 @@
 						<testTarget>1.8</testTarget>
 					</configuration>
 				</plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.19.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.felix</groupId>
+          <artifactId>maven-bundle-plugin</artifactId>
+          <version>3.2.0</version>
+          <extensions>true</extensions>
+          <configuration>
+            <instructions>
+              <Bundle-Category>Utilities</Bundle-Category>
+              <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+              <Bundle-Description>${project.description}</Bundle-Description>
+              <Bundle-Vendor>Luke Hutchison</Bundle-Vendor>
+            </instructions>
+          </configuration>
+        </plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Hi Luke,

I would like use your classpath scanner in a OSGi compliant runtime like Apache Felix but that would require some additional metadata to be added to the assembled jar file. Would you be up for merging this PR which adds the required OSGi descriptor to the MANIFEST.MF file? It should not have any impact on any current use of the jar and I have tested the maven build.

Thanks,
Niels