### PR TITLE
Whitelisting JARs should not prevent scan directories.

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
@@ -271,6 +271,21 @@ public class ScanSpec {
                             }
                         }
                     }
+                } else if (spec.startsWith("dir:")) {
+                	spec = spec.substring(4);
+                	if (!spec.isEmpty()) {
+                		if (log != null) {
+                            log.log("Only \"dir:\" is supported, \"dir:" + spec + "\" is ignored");
+                        }
+                	} else if (blacklisted) {
+                        // Specifying "-dir:" blacklists all directories for scanning
+                        scanNonJars = false;
+                	} else {
+                		// Specifying "dir:" means nothing because directories are scanned by default
+                		if (log != null) {
+                            log.log("\"dir:\" is ignored, only \"-dir:\" is supported");
+                        }
+                	}
                 } else {
                     // Convert classname format to relative path
                     final String specPath = spec.replace('.', '/');
@@ -309,10 +324,6 @@ public class ScanSpec {
         }
         uniqueWhitelistedPathPrefixes.removeAll(uniqueBlacklistedPathPrefixes);
         whitelistedJars.removeAll(blacklistedJars);
-        if (!(whitelistedJars.isEmpty() && whitelistedJarPatterns.isEmpty())) {
-            // Specifying "jar:somejar.jar" causes only the specified jarfile to be scanned
-            scanNonJars = false;
-        }
         if (!scanJars && !scanNonJars) {
             // Can't disable scanning of everything, so if specified, arbitrarily pick one to re-enable.
             if (log != null) {

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpecTest.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpecTest.java
@@ -1,0 +1,29 @@
+package io.github.lukehutch.fastclasspathscanner.scanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class ScanSpecTest {
+
+	@Test
+	public void testConcreteJars() {
+		ScanSpec scanSpec = new ScanSpec(new String[]{"jar:abc.jar"}, null);
+		assertThat(scanSpec.scanDirs).as("specifying concrete jar not excludes dirs").isTrue(); 
+	}
+	
+	@Test
+	public void testOnlyJars() {
+		ScanSpec scanSpec = new ScanSpec(new String[]{"jar:"}, null);
+		assertThat(scanSpec.scanDirs).as("jar only exclude dirs").isFalse();
+	}
+	
+	@Test
+	public void testConcreteJarsAndNoDirs() {
+		ScanSpec scanSpec = new ScanSpec(new String[]{"jar:abc.jar","-dir:"}, null);
+		assertThat(scanSpec.scanDirs).as("no dirs exclude dirs").isFalse(); 
+	}
+
+
+
+}


### PR DESCRIPTION
Applications consist of 2 parts: third party code and my code. I can
speed up classpath scanning by providing list of JARs I want to scan.
If I want scan my own artifacts, I have a problem launching application
from Eclipse. If my own artifact is opened as a project, Eclipse will
attach to classpath folder "target" of the artifact, not JAR. 

Finding which success in Spring Boot standalone application or plain WAR
application on Tomcat will fail in application running from Eclipse.

I don't want modify scanner whitelist for running from Eclipse. A
solution is revert current default and scan classpath directories even
with whitelisted JARs.

I expect performance impact is low because large applications has most
of code packed into JARs and directories are little comparing to JARs.
However, previous default is still possible to configure by
specification "-dir:".

Specification "jar:" (JARs only) is still respected and disables
directory scanning.