### PR TITLE
add bundle itself as a classpath element if it does not have Bundle-Classpath

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/FelixClassLoaderHandler.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/FelixClassLoaderHandler.java
@@ -96,6 +96,8 @@ public class FelixClassLoaderHandler implements ClassLoaderHandler {
                                     classpathFinder.addClasspathElement(jarPath, log);
                                 }
                             }
+                        } else {
+                            classpathFinder.addClasspathElement(bundleFile.replace("reference:", JAR_FILE_PREFIX), log);
                         }
                     }
                     return true;


### PR DESCRIPTION
If an OSGi bundle does not have a Bundle-Classpath statement then it'll be simply skipped by the FelixClassLoaderHandler. This simple fix adds the bundle itself as a classpath element for scanning.

Can't say if this is a universal solution, but works for me. May be we should always add the bundle, even if it does have a Bundle-Classpath? 