### PR TITLE
Issue #130 Add more classloaders for Traditional Websphere

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/WebsphereTraditionalClassLoaderHandler.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/WebsphereTraditionalClassLoaderHandler.java
@@ -37,7 +37,10 @@ public class WebsphereTraditionalClassLoaderHandler implements ClassLoaderHandle
     public boolean handle(final ClassLoader classloader, final ClasspathFinder classpathFinder, final LogNode log)
             throws Exception {
         for (Class<?> c = classloader.getClass(); c != null; c = c.getSuperclass()) {
-            if (!"com.ibm.ws.classloader.CompoundClassLoader".equals(c.getName())) {
+            // All three class loaders implement the getClassPath method call.
+            if (!"com.ibm.ws.classloader.CompoundClassLoader".equals(c.getName())
+                    || !"com.ibm.ws.classloader.ProtectionClassLoader".equals(c.getName())
+                        || !"com.ibm.ws.bootstrap.ExtClassLoader".equals(c.getName())) {
                 continue;
             }
             final String classpath = (String) ReflectionUtils.invokeMethod(classloader, "getClassPath");


### PR DESCRIPTION
Unsure whether we should add @sbespalov, could you give your thoughts? The consequence is that scanning will obviously take longer. Also - the ProtectionClassLoader is there for a reason: we might want to prevent access to it?

Further - I updated this fork by rebasing. Not sure if you want to merge like it is or cimply cherry pick my commit.