### PR TITLE
~ fix for issue 141

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>io.github.lukehutch</groupId>
@@ -194,6 +195,13 @@
 			<groupId>javax.enterprise</groupId>
 			<artifactId>cdi-api</artifactId>
 			<version>1.0-SP4</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.ops4j.pax.url</groupId>
+			<artifactId>pax-url-aether</artifactId>
+			<version>2.5.2</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ClassfileBinaryParser.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ClassfileBinaryParser.java
@@ -557,8 +557,14 @@ class ClassfileBinaryParser implements AutoCloseable {
             case 18: // invoke dynamic
                 skip(4);
                 break;
+            case 19: // see https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.4
+              skip(2);
+              break;
+            case 20: // see https://docs.oracle.com/javase/specs/jvms/se9/html/jvms-4.html#jvms-4.4
+              skip(2);
+              break;  
             default:
-                throw new RuntimeException("Unknown constant pool tag " + tag + " in classfile " + relativePath
+                throw new RuntimeException("Unknown constant pool tag " + tag[i] + " in classfile " + relativePath
                         + " (element size unknown, cannot continue reading class. Please report this on "
                         + "the FastClasspathScanner GitHub page.");
             }
@@ -568,6 +574,12 @@ class ClassfileBinaryParser implements AutoCloseable {
         final int classModifierFlags = readUnsignedShort();
         final boolean isInterface = (classModifierFlags & 0x0200) != 0;
         final boolean isAnnotation = (classModifierFlags & 0x2000) != 0;
+        final boolean isModule = (classModifierFlags & 0x8000) != 0;
+        
+        // don't process module-info class files
+        if (isModule) {
+          return null;
+        }
 
         // The fully-qualified class name of this class, with slashes replaced with dots
         final String classNamePath = getConstantPoolString(readUnsignedShort());

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue141/Issue141Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue141/Issue141Test.java
@@ -1,0 +1,61 @@
+/*
+ * This file is part of FastClasspathScanner.
+ * 
+ * Author: Luke Hutchison
+ * 
+ * Hosted at: https://github.com/lukehutch/fast-classpath-scanner
+ * 
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Luke Hutchison
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.lukehutch.fastclasspathscanner.issues.issue141;
+
+import static org.assertj.core.api.StrictAssertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import org.junit.Test;
+import org.ops4j.pax.url.mvn.MavenResolvers;
+
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+
+public class Issue141Test {
+  
+  @Test
+  public void issue141Test() throws IOException {
+
+    // resolve and download org.ow2.asm:asm:6.0_BETA (which contains a module-info.class)
+    File resolvedFile = MavenResolvers.createMavenResolver(null, null).resolve("org.ow2.asm", "asm", null, null,
+        "6.0_BETA");
+
+    //
+    assertThat(resolvedFile).isFile();
+
+    // create a new custom class loader
+    final ClassLoader classLoader = new URLClassLoader(new URL[] { resolvedFile.toURI().toURL() }, null);
+
+    // scan the classpath
+    new FastClasspathScanner().overrideClassLoaders(classLoader).scan();
+  }
+}


### PR DESCRIPTION
I added support for the new module-related constant pool tags to prevent the RuntimeException.

In case that a module-info.class is parsed, I simply return null in readClassInfoFromClassfileHeader (should be ok, as we won't search for module-info classes anyway!?) 