### PR TITLE
JBossClassLoader: upgrade to jboss modules 1.6

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/JBossClassLoaderHandler.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/classloaderhandler/JBossClassLoaderHandler.java
@@ -30,6 +30,7 @@ package io.github.lukehutch.fastclasspathscanner.classloaderhandler;
 
 import java.io.File;
 import java.lang.reflect.Array;
+import java.nio.file.Path;
 import java.util.Map;
 
 import io.github.lukehutch.fastclasspathscanner.scanner.ClasspathFinder;
@@ -92,8 +93,13 @@ public class JBossClassLoaderHandler implements ClassLoaderHandler {
                             // Fallback
                             path = (String) ReflectionUtils.invokeMethod(root, "getPathName");
                             if (path == null) {
-                                // Try File:
-                                Object file = root;
+                                // Try Path or File:
+                                Object file;
+                                if (root instanceof Path) {
+                                    file = ((Path) root).toFile();
+                                } else {
+                                    file = root;
+                                }
                                 if (file == null) {
                                     // Try JarFileResource:
                                     file = ReflectionUtils.getFieldVal(resourceLoader, "fileOfJar");


### PR DESCRIPTION
- In 1.6.x the existing FileResourceLoader extends from PathResourceLoader which now uses a java.nio.file.Path as `root` object, previous version this was a `java.io.File`
- It is a simply/fallback fix