### PR TITLE
Proposed fix for Issue 167

### DIFF
--- a/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
+++ b/src/main/java/io/github/lukehutch/fastclasspathscanner/scanner/ScanSpec.java
@@ -36,6 +36,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map.Entry;
@@ -407,6 +408,11 @@ public class ScanSpec {
                 log.log("Scanning of jars and dirs are both disabled -- re-enabling scanning of dirs");
             }
             scanDirs = true;
+        }
+
+        // Sort the whitelistedPathPrefixes to ensure correct evaluation (but only if we have prefixes specified)
+        if (!uniqueWhitelistedPathPrefixes.isEmpty()) {
+            Collections.sort(whitelistedPathPrefixes);
         }
 
         if (log != null) {

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/Issue167Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/Issue167Test.java
@@ -1,0 +1,70 @@
+/*
+ * This file is part of FastClasspathScanner.
+ * 
+ * Author: Richard Begg
+ * 
+ * Hosted at: https://github.com/lukehutch/fast-classpath-scanner
+ * 
+ * --
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Luke Hutchison
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without
+ * limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so, subject to the following
+ * conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT
+ * LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+ * EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+ * OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+package io.github.lukehutch.fastclasspathscanner.issues.issue167;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.github.lukehutch.fastclasspathscanner.issues.issue167.a.b.TestAB;
+import io.github.lukehutch.fastclasspathscanner.issues.issue167.a.TestA;
+
+public class Issue167Test {
+  public static List<Class<?>> classes = Arrays.asList(new Class<?>[] {TestA.class,TestAB.class});
+  public static List<String> packages = classes.stream().map(c -> c.getPackage().getName()).collect(Collectors.toList());
+  public static List<String> classNames = classes.stream().map(c -> c.getName()).collect(Collectors.toList());
+
+    @Test
+    public void scanPackagesTest1() throws IOException {
+        assertEquals(classNames,new FastClasspathScanner(packages.toArray(new String[packages.size()]))
+            .disableRecursiveScanning()
+            .scan()
+            .getNamesOfAllClasses());
+    }
+
+    @Test
+    public void scanPackagesTest2() throws IOException {
+        List<String> reversedPackages = new ArrayList<>(packages);
+        Collections.reverse(reversedPackages);
+        assertEquals(classNames,new FastClasspathScanner(reversedPackages.toArray(new String[reversedPackages.size()]))
+            .disableRecursiveScanning()
+            .scan()
+            .getNamesOfAllClasses());
+    }
+
+}

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/a/TestA.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/a/TestA.java
@@ -1,0 +1,4 @@
+package io.github.lukehutch.fastclasspathscanner.issues.issue167.a;
+
+public class TestA {
+}

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/a/b/TestAB.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue167/a/b/TestAB.java
@@ -1,0 +1,4 @@
+package io.github.lukehutch.fastclasspathscanner.issues.issue167.a.b;
+
+public class TestAB {
+}


### PR DESCRIPTION
Sort the whitelisted path prefixes to ensure that scannable packages that are also ancestors are correctly evaluated.

Also included a test case to illustrate the issue.