### PR TITLE
Update AssertJ to version 3.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
 		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
-			<version>3.1.0</version>
+			<version>3.10.0</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/TestGetUniqueClasspathElements.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/TestGetUniqueClasspathElements.java
@@ -1,7 +1,6 @@
 package io.github.lukehutch.fastclasspathscanner.issues;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
 
 import org.junit.Test;
 

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue103/Issue103Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue103/Issue103Test.java
@@ -29,7 +29,6 @@
 package io.github.lukehutch.fastclasspathscanner.issues.issue103;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue140/Issue140Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue140/Issue140Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue140;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.lang.reflect.Array;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue141/Issue141Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue141/Issue141Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue141;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue146/Issue146Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue146/Issue146Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue146;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue148/Issue148Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue148/Issue148Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue148;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue151/Issue151Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue151/Issue151Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue151;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.lang.annotation.ElementType;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue152/Issue152Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue152/Issue152Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue152;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue153/Issue153Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue153/Issue153Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue153;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.lang.annotation.Retention;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue183/Issue183Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue183/Issue183Test.java
@@ -28,7 +28,7 @@
  */
 package io.github.lukehutch.fastclasspathscanner.issues.issue183;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue193/Issue193Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue193/Issue193Test.java
@@ -29,7 +29,7 @@
 package io.github.lukehutch.fastclasspathscanner.issues.issue193;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue83/Issue83Test.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue83/Issue83Test.java
@@ -1,7 +1,6 @@
 package io.github.lukehutch.fastclasspathscanner.issues.issue83;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
 
 import java.net.URL;
 import java.net.URLClassLoader;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue88/Issue88.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/issues/issue88/Issue88.java
@@ -1,6 +1,6 @@
 package io.github.lukehutch.fastclasspathscanner.issues.issue88;
 
-import static org.assertj.core.api.StrictAssertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/test/ClassInfoTest.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/test/ClassInfoTest.java
@@ -1,7 +1,6 @@
 package io.github.lukehutch.fastclasspathscanner.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
 
 import java.util.List;
 import java.util.Map;

--- a/src/test/java/io/github/lukehutch/fastclasspathscanner/test/FastClasspathScannerTest.java
+++ b/src/test/java/io/github/lukehutch/fastclasspathscanner/test/FastClasspathScannerTest.java
@@ -29,7 +29,6 @@
 package io.github.lukehutch.fastclasspathscanner.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.StrictAssertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;


### PR DESCRIPTION
`StrictAssertions` has been replaced by `AssertionsForClassTypes`, but most of the time `Assertions` can be used instead of  `AssertionsForInterfaceTypes` or `AssertionsForClassTypes`.